### PR TITLE
Fix double response to scope errors (Fixes #89)

### DIFF
--- a/bot/src/command.rs
+++ b/bot/src/command.rs
@@ -116,19 +116,7 @@ impl Context {
     /// Verify that the current user has the associated scope.
     pub async fn check_scope(&self, scope: Scope) -> Result<()> {
         if !self.user.has_scope(scope).await {
-            if let Some(name) = self.user.display_name() {
-                self.privmsg(format!(
-                    "Do you think this is a democracy {name}? LUL",
-                    name = name,
-                ))
-                .await;
-            }
-
-            bail!(
-                "Scope `{}` not associated with user {:?}",
-                scope,
-                self.user.name()
-            );
+            respond_bail!("Do you think this is a democracy? LUL");
         }
 
         if self.user.has_scope(Scope::BypassCooldowns).await {
@@ -141,13 +129,10 @@ impl Context {
             let now = Instant::now();
 
             if let Some(duration) = cooldown.check(now.clone()) {
-                self.respond(format!(
+                respond_bail!(
                     "Cooldown in effect for {}",
                     utils::compact_duration(duration),
-                ))
-                .await;
-
-                bail!("Scope `{}` is in cooldown", scope);
+                )
             }
 
             cooldown.poke(now);

--- a/bot/src/irc/mod.rs
+++ b/bot/src/irc/mod.rs
@@ -781,12 +781,8 @@ pub async fn process_command(
                     if !ctx.user.has_scope(scope).await {
                         if ctx.user.is_moderator() {
                             respond!(ctx, "You are not allowed to run that command");
-                        } else if let Some(display_name) = ctx.user.display_name() {
-                            ctx.privmsg(format!(
-                                "Do you think this is a democracy {name}? LUL",
-                                name = display_name
-                            ))
-                            .await;
+                        } else {
+                            respond!(ctx, "Do you think this is a democracy? LUL");
                         }
 
                         return Ok(());


### PR DESCRIPTION
Fixes #89 

The issue was caused by the `check_scope` method responding using `self.privmsg()` and also throwing an error, which made the IRC module send another response here:
https://github.com/udoprog/OxidizeBot/blob/e987d6d64992c04ceaf4b02966f7f8b735abb61a/bot/src/irc/mod.rs#L797-L804
Also modified another error response in the IRC module for consistency.