### PR TITLE
Fix response of devices endpoint (Fixes #82)

### DIFF
--- a/bot/src/command.rs
+++ b/bot/src/command.rs
@@ -4,7 +4,7 @@ use crate::auth::Scope;
 use crate::irc;
 use crate::prelude::*;
 use crate::utils;
-use anyhow::{bail, Result};
+use anyhow::Result;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;

--- a/bot/src/web/mod.rs
+++ b/bot/src/web/mod.rs
@@ -40,8 +40,11 @@ struct CustomReject(anyhow::Error);
 
 impl warp::reject::Reject for CustomReject {}
 
+// TODO: Also log which endpoint caused the error
 pub(crate) fn custom_reject(error: impl Into<anyhow::Error>) -> warp::Rejection {
-    warp::reject::custom(CustomReject(error.into()))
+    let error = error.into();
+    log::error!("Endpoint error caused by: {}", error);
+    warp::reject::custom(CustomReject(error))
 }
 
 #[derive(Debug)]

--- a/bot/src/web/mod.rs
+++ b/bot/src/web/mod.rs
@@ -831,7 +831,13 @@ impl Api {
         };
 
         let c = player.current_device().await;
-        let data = player.list_devices().await?;
+        let data = match player.list_devices().await {
+            Ok(data) => data,
+            Err(_) => {
+                let data = Devices::default();
+                return Ok(warp::reply::json(&data));
+            }
+        };
 
         let mut devices = Vec::new();
         let mut current = None;

--- a/bot/src/web/mod.rs
+++ b/bot/src/web/mod.rs
@@ -1237,6 +1237,16 @@ async fn recover(err: warp::Rejection) -> Result<impl warp::Reply, warp::Rejecti
         });
 
         Ok(warp::reply::with_status(json, code))
+    } else if let Some(e) = err.find::<CustomReject>() {
+        let json = warp::reply::json(&ErrorMessage {
+            code: 500,
+            message: e.0.to_string(),
+        });
+
+        Ok(warp::reply::with_status(
+            json,
+            warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+        ))
     } else {
         // Could be a NOT_FOUND, or METHOD_NOT_ALLOWED... here we just
         // let warp use its default rendering.


### PR DESCRIPTION
Fixes #82 
Also removed an unused import I missed last time.

This fixes the issue of the *devices* endpoint sending an error when Spotify isn't authorized.

It does not fix the underlying issue of endpoint errors sending an HTML response, which the UI `fetch` function cannot parse as JSON, resulting in the exception described in #82. That should probably be changed to provide a more useful error message, instead of the current `Unexpected token < in JSON ...`.