### PR TITLE
Change duplicate-duration behaviour

### DIFF
--- a/bot/migrations/2021-04-10-125642_songs_add_played/down.sql
+++ b/bot/migrations/2021-04-10-125642_songs_add_played/down.sql
@@ -1,0 +1,15 @@
+CREATE TABLE songs2 (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    track_id VARCHAR NOT NULL,
+    added_at TIMESTAMP NOT NULL,
+    user VARCHAR,
+    promoted_at TIMESTAMP DEFAULT NULL,
+    promoted_by VARCHAR DEFAULT NULL
+);
+
+INSERT INTO songs2 (id, deleted, track_id, added_at, user, promoted_at, promoted_by) 
+SELECT id, (deleted OR played) AS deleted, track_id, added_at, user, promoted_at, promoted_by FROM songs;
+
+DROP TABLE songs;
+ALTER TABLE songs2 RENAME TO songs;

--- a/bot/migrations/2021-04-10-125642_songs_add_played/up.sql
+++ b/bot/migrations/2021-04-10-125642_songs_add_played/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE songs
+ADD COLUMN played BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE songs
+SET
+    played = deleted,
+    deleted = FALSE;

--- a/bot/src/db/models.rs
+++ b/bot/src/db/models.rs
@@ -119,7 +119,9 @@ pub struct BadWord {
 pub struct Song {
     /// ID of the song request.
     pub id: i32,
-    /// If the request is deleted or not.
+    /// If the request already played or not.
+    pub played: bool,
+    /// If the request was deleted or not.
     pub deleted: bool,
     /// The track id of the song.
     pub track_id: TrackId,

--- a/bot/src/db/schema.rs
+++ b/bot/src/db/schema.rs
@@ -40,6 +40,7 @@ table! {
     songs (id) {
         id -> Integer,
         deleted -> Bool,
+        played -> Bool,
         track_id -> Text,
         added_at -> Timestamp,
         promoted_at -> Nullable<Timestamp>,

--- a/bot/src/player/mixer.rs
+++ b/bot/src/player/mixer.rs
@@ -114,7 +114,7 @@ impl Mixer {
         }
 
         if let Some(item) = self.queue.remove(n) {
-            self.db.player_remove_song(&item.track_id).await?;
+            self.db.player_remove_song(&item.track_id, true).await?;
             return Ok(Some(item));
         }
 
@@ -128,7 +128,7 @@ impl Mixer {
         }
 
         if let Some(item) = self.queue.pop_back() {
-            self.db.player_remove_song(&item.track_id).await?;
+            self.db.player_remove_song(&item.track_id, true).await?;
             return Ok(Some(item));
         }
 
@@ -147,7 +147,7 @@ impl Mixer {
             .rposition(|i| i.user.as_ref().map(|u| u == user).unwrap_or_default())
         {
             if let Some(item) = self.queue.remove(position) {
-                self.db.player_remove_song(&item.track_id).await?;
+                self.db.player_remove_song(&item.track_id, true).await?;
                 return Ok(Some(item));
             }
         }
@@ -238,7 +238,7 @@ impl Mixer {
     /// Pop the front of the queue.
     async fn pop_front(&mut self) -> Result<Option<Arc<Item>>> {
         if let Some(item) = self.queue.pop_front() {
-            self.db.player_remove_song(&item.track_id).await?;
+            self.db.player_remove_song(&item.track_id, false).await?;
             Ok(Some(item))
         } else {
             Ok(None)

--- a/bot/src/player/mixer.rs
+++ b/bot/src/player/mixer.rs
@@ -114,7 +114,7 @@ impl Mixer {
         }
 
         if let Some(item) = self.queue.remove(n) {
-            self.db.player_remove_song(&item.track_id, true).await?;
+            self.db.player_remove_song(&item.track_id, false).await?;
             return Ok(Some(item));
         }
 
@@ -128,7 +128,7 @@ impl Mixer {
         }
 
         if let Some(item) = self.queue.pop_back() {
-            self.db.player_remove_song(&item.track_id, true).await?;
+            self.db.player_remove_song(&item.track_id, false).await?;
             return Ok(Some(item));
         }
 
@@ -147,7 +147,7 @@ impl Mixer {
             .rposition(|i| i.user.as_ref().map(|u| u == user).unwrap_or_default())
         {
             if let Some(item) = self.queue.remove(position) {
-                self.db.player_remove_song(&item.track_id, true).await?;
+                self.db.player_remove_song(&item.track_id, false).await?;
                 return Ok(Some(item));
             }
         }
@@ -238,7 +238,7 @@ impl Mixer {
     /// Pop the front of the queue.
     async fn pop_front(&mut self) -> Result<Option<Arc<Item>>> {
         if let Some(item) = self.queue.pop_front() {
-            self.db.player_remove_song(&item.track_id, false).await?;
+            self.db.player_remove_song(&item.track_id, true).await?;
             Ok(Some(item))
         } else {
             Ok(None)


### PR DESCRIPTION
Fixes #109 

`!song purge` and `!song delete` commands now let a song get requested again.

It might be better to rename the `songs::deleted` column to something like `played`, as "deleting" now refers to two distinct operations. 