### PR TITLE
Add ability to temporarily deny scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/bot/src/auth.yaml
+++ b/bot/src/auth.yaml
@@ -232,7 +232,7 @@ scopes:
       - "@moderator"
   auth/permit:
     doc: >
-      If you are allowed to run `!auth permit` to grant temporary scopes.
+      If you are allowed to run `!auth allow` to grant temporary scopes or `!auth deny` to deny them.
       You are only able to grant scopes which you yourself have access to.
     version: 0
     allow:

--- a/bot/src/setbac.rs
+++ b/bot/src/setbac.rs
@@ -87,7 +87,7 @@ where
                         continue;
                     };
 
-                    tracing::trace!("Pushing remote player update");
+                    tracing::info!("Sending remote player update");
 
                     let mut update = PlayerUpdate::default();
                     update.current = player.current().await.map(|c| c.item().as_ref().into());

--- a/bot/src/sys/windows/window.rs
+++ b/bot/src/sys/windows/window.rs
@@ -20,7 +20,7 @@ use crate::sys::Notification;
 
 const ICON_MSG_ID: UINT = WM_USER + 1;
 
-thread_local!(static WININFO_STASH: RefCell<Option<WindowsLoopData>> = RefCell::new(None));
+thread_local!(static WININFO_STASH: RefCell<Option<WindowsLoopData>> = const { RefCell::new(None) });
 
 /// Copy a wide string from a source to a destination.
 pub(crate) fn copy_wstring(dest: &mut [u16], source: &str) {

--- a/crates/oxidize-auth/Cargo.toml
+++ b/crates/oxidize-auth/Cargo.toml
@@ -14,3 +14,4 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 chrono = { workspace = true }
+tracing = { workspace = true }

--- a/crates/oxidize-chat/src/chat.rs
+++ b/crates/oxidize-chat/src/chat.rs
@@ -628,16 +628,16 @@ async fn process_command<'a>(
             if let Some(handler) = handler {
                 let scope = handler.scope();
 
-                tracing::info! {
-                    ?scope,
-                    roles = ?ctx.user.roles(),
-                    principal = ?ctx.user.principal(),
-                    "Testing handler scope"
-                };
-
                 // Test if user has the required scope to run the given
                 // command.
                 if let Some(scope) = scope {
+                    tracing::info! {
+                        ?scope,
+                        roles = ?ctx.user.roles(),
+                        principal = ?ctx.user.principal(),
+                        "Testing handler scope"
+                    };
+
                     if !ctx.user.has_scope(scope).await {
                         if ctx.user.is_moderator() {
                             let m = ctx.messages.get(messages::AUTH_FAILED).await;

--- a/crates/oxidize-chat/src/currency_admin.rs
+++ b/crates/oxidize-chat/src/currency_admin.rs
@@ -154,7 +154,7 @@ impl command::Handler for Handler {
                 if !ctx.user.is_streamer() && ctx.user.is(&boosted_user) {
                     respond!(
                         ctx,
-                        "You gonna have to play by the rules (or ask another mod) :("
+                        "You're gonna have to play by the rules (or ask the streamer nicely) :("
                     );
                     return Ok(());
                 }

--- a/crates/oxidize-currency/src/mysql.rs
+++ b/crates/oxidize-currency/src/mysql.rs
@@ -289,9 +289,8 @@ impl Backend {
 
         let balance = self.queries.select_balance(&mut tx, &user).await?;
 
-        let balance = match balance {
-            Some(b) => b.try_into()?,
-            None => return Ok(None),
+        let Some(balance) = balance.map(i64::from) else {
+            return Ok(None);
         };
 
         Ok(Some(BalanceOf {

--- a/crates/oxidize-db/src/lib.rs
+++ b/crates/oxidize-db/src/lib.rs
@@ -258,7 +258,7 @@ pub enum RenameError {
     Missing,
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {
     use super::user_id;
 

--- a/crates/oxidize-player/src/mixer.rs
+++ b/crates/oxidize-player/src/mixer.rs
@@ -209,7 +209,7 @@ impl Mixer {
                 queue.push_front(removed);
             }
 
-            queue.get(0).cloned()
+            queue.front().cloned()
         };
 
         if let Some(item) = next {

--- a/shared/commands.toml
+++ b/shared/commands.toml
@@ -914,9 +914,18 @@ SetMod: setbac -> @moderator: song/playback-control, song/spotify, song/list-lim
 """
 
 [[groups.commands]]
-name = "!auth permit `<duration>` `<principal>` `<scope>`"
+name = "!auth allow `<duration>` `<principal>` `<scope>`"
 content = """
 Grant a `<scope>` to `<principal>` for `<duration>`.
+
+`<principal>` can either be a role (e.g. _@everyone_ or _@subscriber_) or a user (without _@_).
+`<duration>` has to be formatted as `[<days>d][<hours>h][<minutes>m][<seconds>s]`, like _5d10m30s_ or _5m_.
+"""
+
+[[groups.commands]]
+name = "!auth deny `<duration>` `<principal>` `<scope>`"
+content = """
+Deny a `<scope>` to `<principal>` for `<duration>`.
 
 `<principal>` can either be a role (e.g. _@everyone_ or _@subscriber_) or a user (without _@_).
 `<duration>` has to be formatted as `[<days>d][<hours>h][<minutes>m][<seconds>s]`, like _5d10m30s_ or _5m_.

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -11,6 +11,9 @@
 //! <br>
 //!
 //! The web component of OxidizeBot, a high performance Twitch Bot powered by Rust.
+
+#![allow(clippy::enum_variant_names)]
+
 mod aead;
 mod api;
 mod db;


### PR DESCRIPTION
This adds the `!auth deny` command to insert a temporary deny.

To for example deny song requests for a day, you ca do the following:

```
!auth deny 1d <user> song/request
```