### PR TITLE
api: be more relaxed with status codes

### DIFF
--- a/crates/oxidize-api/src/spotify.rs
+++ b/crates/oxidize-api/src/spotify.rs
@@ -279,11 +279,11 @@ impl Spotify {
     }
 }
 
-/// Handle device control requests.
+/// Handle device control responses.
 fn device_control<C>(status: StatusCode, _: &C) -> Result<Option<bool>> {
     match status {
-        StatusCode::NO_CONTENT => Ok(Some(true)),
         StatusCode::NOT_FOUND => Ok(Some(false)),
+        status if status.is_success() => Ok(Some(true)),
         _ => Ok(None),
     }
 }


### PR DESCRIPTION
Issue reported by @halvkyrie over Discord

API sometimes report 200 OK, since this is behaviorally equivalent let's support it and other 2xx for more resilience.