### PR TITLE
Support intl- URLs

### DIFF
--- a/crates/oxidize-chat/src/command.rs
+++ b/crates/oxidize-chat/src/command.rs
@@ -282,7 +282,7 @@ impl<'a> Context<'a> {
     }
 }
 
-impl<'a> Iterator for Context<'a> {
+impl Iterator for Context<'_> {
     type Item = String;
 
     #[inline]

--- a/crates/oxidize-chat/src/utils.rs
+++ b/crates/oxidize-chat/src/utils.rs
@@ -11,7 +11,7 @@ impl<'a> Urls<'a> {
     }
 }
 
-impl<'a> Iterator for Urls<'a> {
+impl Iterator for Urls<'_> {
     type Item = url::Url;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/oxidize-common/src/models/track_id.rs
+++ b/crates/oxidize-common/src/models/track_id.rs
@@ -107,6 +107,8 @@ impl TrackId {
                     let id = match parts.as_slice() {
                         ["", "track", id] => SpotifyId::from_base62(id)
                             .map_err(|_| FromStrError::BadBase62((*id).to_string()))?,
+                        ["", _intl_part, "track", id] => SpotifyId::from_base62(id)
+                            .map_err(|_| FromStrError::BadBase62((*id).to_string()))?,
                         _ => return Err(FromStrError::BadUrl(url.to_string())),
                     };
 

--- a/crates/oxidize-common/src/words.rs
+++ b/crates/oxidize-common/src/words.rs
@@ -169,7 +169,7 @@ pub struct Trimmed<'a> {
     string: &'a str,
 }
 
-impl<'a> Trimmed<'a> {
+impl Trimmed<'_> {
     /// Split the commandline.
     fn new(string: &str) -> Trimmed<'_> {
         Trimmed {

--- a/crates/oxidize-db/src/matcher.rs
+++ b/crates/oxidize-db/src/matcher.rs
@@ -264,7 +264,7 @@ pub enum Captures<'a> {
     Regex { captures: regex::Captures<'a> },
 }
 
-impl<'a> Captures<'a> {
+impl Captures<'_> {
     /// Get the number of captures.
     fn len(&self) -> usize {
         match self {

--- a/crates/oxidize-emotes/src/lib.rs
+++ b/crates/oxidize-emotes/src/lib.rs
@@ -822,7 +822,7 @@ pub(crate) struct Words<'a> {
     n: usize,
 }
 
-impl<'a> Words<'a> {
+impl Words<'_> {
     /// Split a string into words.
     pub(crate) fn new(string: &str) -> Words<'_> {
         Words { string, n: 0 }


### PR DESCRIPTION
This has been tested locally. 

Currently just discards the intl- part if it's there, which means you could technically put anything there and still have the link be accepted. 

This is a fix to #217 